### PR TITLE
Update lottery.sol: `block.difficulty` is deprecated

### DIFF
--- a/Level2/Lottery System/lottery.sol
+++ b/Level2/Lottery System/lottery.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.7.0 <0.9.0;
+
 contract Lottery{
     address public manager;
     address payable[] public participants;
@@ -7,17 +8,21 @@ contract Lottery{
     constructor(){
         manager = msg.sender;    
     }
+
     receive() external payable{
         require(msg.value>=100 wei); 
         participants.push(payable(msg.sender));
     }
+
     function getBalance() public view returns(uint){
         require(msg.sender==manager); 
         return address(this).balance;
     }
+
     function random() public view returns(uint){
-        return uint(keccak256(abi.encodePacked(block.difficulty,block.timestamp,participants.length)));    
+        return uint(keccak256(abi.encodePacked(block.prevrandao,block.timestamp,participants.length)));    
     }
+
     function selectWinner() public{
         require(msg.sender==manager);
         require(participants.length>=3);


### PR DESCRIPTION
## 🛠️ Fixes Issue
Actually, the use of `block.difficulty` has been deprecated since the VM version Paris. Now, `block.prevrandao` is used which returns a random number based on the beacon chain

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.